### PR TITLE
feat: add debug logging to diagnose label sync issues [minor]

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -204,30 +204,31 @@ func (r *NodeLabelController) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Create a map for tags to sync with the cloud provider
 	tagsToSync := make(map[string]string)
+	var notFoundLabels, notFoundAnnotations []string
 
 	// First collect labels (may be overwritten by annotations with same key)
-	if node.Labels != nil {
-		for _, k := range r.Labels {
-			if value, exists := node.Labels[k]; exists {
-				tagsToSync[k] = value
-			} else {
-				logger.V(1).Info("Monitored label not found on node", "label", k)
-			}
+	for _, k := range r.Labels {
+		if value, exists := node.Labels[k]; exists {
+			tagsToSync[k] = value
+		} else {
+			notFoundLabels = append(notFoundLabels, k)
 		}
 	}
 
 	// Then collect annotations (will overwrite labels with same key)
-	if node.Annotations != nil {
-		for _, k := range r.Annotations {
-			if value, exists := node.Annotations[k]; exists {
-				tagsToSync[k] = value
-			} else {
-				logger.V(1).Info("Monitored annotation not found on node", "annotation", k)
-			}
+	for _, k := range r.Annotations {
+		if value, exists := node.Annotations[k]; exists {
+			tagsToSync[k] = value
+		} else {
+			notFoundAnnotations = append(notFoundAnnotations, k)
 		}
 	}
 
-	logger.V(1).Info("Collected tags to sync", "tagsToSync", tagsToSync, "monitoredLabels", r.Labels, "monitoredAnnotations", r.Annotations)
+	logger.V(1).Info("Collected tags to sync",
+		"tagsToSync", tagsToSync,
+		"notFoundLabels", notFoundLabels,
+		"notFoundAnnotations", notFoundAnnotations,
+	)
 
 	var err error
 	switch r.Cloud {

--- a/controller.go
+++ b/controller.go
@@ -11,6 +11,7 @@ import (
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/go-logr/logr"
 	gce "google.golang.org/api/compute/v1"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -21,6 +22,7 @@ import (
 
 type NodeLabelController struct {
 	client.Client
+	Logger    logr.Logger
 	EC2Client ec2Client
 	GCEClient gceClient
 
@@ -67,7 +69,22 @@ func (r *NodeLabelController) SetupWithManager(mgr ctrl.Manager) error {
 			if !ok {
 				return false
 			}
-			return shouldProcessNodeUpdate(oldNode, newNode, r.Labels, r.Annotations)
+
+			// Process if any monitored label/annotation changed
+			if shouldProcessNodeUpdate(oldNode, newNode, r.Labels, r.Annotations) {
+				r.Logger.V(1).Info("Update event: label changed", "node", newNode.Name)
+				return true
+			}
+
+			// Also process if node has monitored labels (catches resync events).
+			// During resync, old == new, so shouldProcessNodeUpdate returns false,
+			// but we still want to reconcile to catch any missed events.
+			if shouldProcessNodeCreate(newNode, r.Labels, r.Annotations) {
+				r.Logger.V(1).Info("Update event: resync", "node", newNode.Name)
+				return true
+			}
+
+			return false
 		},
 
 		CreateFunc: func(e event.CreateEvent) bool {
@@ -75,7 +92,14 @@ func (r *NodeLabelController) SetupWithManager(mgr ctrl.Manager) error {
 			if !ok {
 				return false
 			}
-			return shouldProcessNodeCreate(node, r.Labels, r.Annotations)
+			shouldProcess := shouldProcessNodeCreate(node, r.Labels, r.Annotations)
+			r.Logger.V(1).Info("Create event",
+				"node", node.Name,
+				"shouldProcess", shouldProcess,
+				"labels", node.Labels,
+				"monitoredLabels", r.Labels,
+			)
+			return shouldProcess
 		},
 
 		DeleteFunc: func(e event.DeleteEvent) bool {
@@ -164,7 +188,7 @@ func shouldProcessNodeCreate(node *corev1.Node, monitoredLabels, monitoredAnnota
 }
 
 func (r *NodeLabelController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := ctrl.Log.WithName("reconcile").WithValues("node", req.NamespacedName)
+	logger := r.Logger.WithValues("node", req.NamespacedName)
 
 	var node corev1.Node
 	if err := r.Get(ctx, req.NamespacedName, &node); err != nil {
@@ -186,6 +210,8 @@ func (r *NodeLabelController) Reconcile(ctx context.Context, req ctrl.Request) (
 		for _, k := range r.Labels {
 			if value, exists := node.Labels[k]; exists {
 				tagsToSync[k] = value
+			} else {
+				logger.V(1).Info("Monitored label not found on node", "label", k)
 			}
 		}
 	}
@@ -195,9 +221,13 @@ func (r *NodeLabelController) Reconcile(ctx context.Context, req ctrl.Request) (
 		for _, k := range r.Annotations {
 			if value, exists := node.Annotations[k]; exists {
 				tagsToSync[k] = value
+			} else {
+				logger.V(1).Info("Monitored annotation not found on node", "annotation", k)
 			}
 		}
 	}
+
+	logger.V(1).Info("Collected tags to sync", "tagsToSync", tagsToSync, "monitoredLabels", r.Labels, "monitoredAnnotations", r.Annotations)
 
 	var err error
 	switch r.Cloud {

--- a/controller.go
+++ b/controller.go
@@ -238,11 +238,11 @@ func (r *NodeLabelController) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	if err != nil {
-		logger.Error(err, "failed to sync tags")
+		logger.Error(err, "failed to sync tags", "providerID", providerID)
 		return ctrl.Result{}, err
 	}
 
-	logger.Info("Successfully synced tags to cloud provider", "tags", tagsToSync)
+	logger.Info("Successfully synced tags to cloud provider", "providerID", providerID, "tags", tagsToSync)
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
When investigating potential issues with node labels syncing to EC2 was no visibility into the controller's decision-making. The predicates silently filter events, and reconcile doesn't log which labels it finds vs expects. Without this, debugging requires guessing whether the predicate rejected the event or the label simply wasn't on the node.

Adds V(1) debug logs throughout the sync pipeline. The predicate now logs every Create/Update event with `shouldProcess=true/false` so you can see if events are being filtered. Reconcile logs which monitored labels are missing from the node and the final set of tags being synced.

Replaces the custom `--json` flag with controller-runtime's standard zap flags (`--zap-log-level`, `--zap-encoder`, etc). To see debug logs, run with `--zap-log-level=debug` or `--zap-log-level=1`.

Additionally, introduce a new 4 hour resync period and update the predicate on Update events to allow a full resync to the cloud provider to catch any potentially missed label sync events. This is a trade-off between eventual consistency and the cost of the extra DescribeTags calls.

> NOTE: Due to the dropping of `--json` flag and replacing with zap flags,
> the minor version is being bumped to v0.1.0.