### PR TITLE
fix: too frequent cloud api updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/planetscale/k8s-node-tagger
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.5
+toolchain go1.25.5
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.5


### PR DESCRIPTION
The previous release introduced debug logging and new logic to attempt to work around potential edge cases where node label updates were being missed. This resulted in too frequent cloud api updates on every node change such as regular node status updates. This could be observed in the logs by nodes having their tags resynced every ~5minutes.

This commit attempts to distinguish between real node label updates and periodic cache resync events. The 4 hour cache sync period remains in place to catch any missed events.